### PR TITLE
Saves `SDCardMode` to the config file.

### DIFF
--- a/source/settings/CSettings.cpp
+++ b/source/settings/CSettings.cpp
@@ -400,6 +400,7 @@ bool CSettings::Save()
 	fprintf(file, "MultiplePartitions = %d\n", MultiplePartitions);
 	fprintf(file, "USBPort = %d\n", USBPort);
 	fprintf(file, "USBAutoMount = %d\n", USBAutoMount);
+	fprintf(file, "SDMode = %d\n", SDMode);
 	fprintf(file, "BlockIOSReload = %d\n", BlockIOSReload);
 	fprintf(file, "WSFactor = %0.3f\n", WSFactor);
 	fprintf(file, "FontScaleFactor = %0.3f\n", FontScaleFactor);
@@ -558,7 +559,11 @@ bool CSettings::ValidateURL(char *value, int type)
 
 bool CSettings::SetSetting(char *name, char *value)
 {
-	if (strcmp(name, "godmode") == 0)
+	if (strcmp(name, "SDMode") == 0)
+	{
+		SDMode = atoi(value);
+	}
+	else if (strcmp(name, "godmode") == 0)
 	{
 		godmode = atoi(value);
 		return true;

--- a/source/settings/CSettings.h
+++ b/source/settings/CSettings.h
@@ -243,11 +243,11 @@ class CSettings
 		short GCInstallCompressed;
 		short GCInstallAligned;
 		short PrivateServer;
+		short SDMode;
 
 		// These variables are not saved to the settings file
 		bool FirstTimeRun;
 		bool skipSaving;
-		short SDMode;
 	protected:
 		bool ValidVersion(FILE * file);
 		bool ValidateURL(char *value, int type = 0);


### PR DESCRIPTION
When using an external USB for anything other than loading games (say, storing movies), USB Loader GX will attempt to load the external USB regardless if `SDCardMode` is set to `true` or `false`. This is because `SDCardMode` is (seemingly intentionally?) not saved to the config file. As a result, regardless if you have explicitly set `SDCardMode` to `true` or `false`, USB Loader GX will unconditionally mount any available USBs.